### PR TITLE
Update VRCombat.java - fix ViveCraft 1.20 Update - VR Combat Crash

### DIFF
--- a/src/main/java/elocindev/vrcombat/fabric/VRCombat.java
+++ b/src/main/java/elocindev/vrcombat/fabric/VRCombat.java
@@ -18,11 +18,5 @@ public class VRCombat implements ClientModInitializer {
 	public void onInitializeClient() {
 		CONFIG = ConfigBuilder.loadConfig();
 		LOGGER.info("VRCombat Config Initialized!");
-
-		if (VRState.vrInitialized) {
-			LOGGER.info("VRCombat detected Vivecraft VR Mode, may be hotswapped later!");
-		} else {
-			LOGGER.info("VRCombat detected Vivecraft NONVR Mode, may be hotswapped later!");
-		}
 	}
 }


### PR DESCRIPTION
simple fix when VR Combat Crash with
"java.lang.RuntimeException: Could not execute entrypoint stage 'client' due to errors, provided by 'vr-combat' at 'elocindev.vrcombat.fabric.VRCombat'!"